### PR TITLE
Changing RESTEasy repository link for EAP 6.4

### DIFF
--- a/streams.json
+++ b/streams.json
@@ -348,8 +348,8 @@
         },
         {
           "component_name": "RESTEasy",
-          "repository_url": "https://github.com/resteasy/Resteasy",
-          "codebase": "Branch_2_3"
+          "repository_url": "https://github.com/jbossas/redhat-resteasy",
+          "codebase": "2.3.x"
         },
         {
           "component_name": "Web",


### PR DESCRIPTION
Updating link for RESTEasy 2.3.x. Per email from Ron Sigal, any update to RESTEasy 2.x should go into https://github.com/jbossas/redhat-resteasy repository.