### PR TITLE
Update wildfly/wildfly-core community branch from master to main

### DIFF
--- a/streams.json
+++ b/streams.json
@@ -2302,7 +2302,7 @@
           ],
           "repository_type": "GIT",
           "repository_url": "https://github.com/wildfly/wildfly-core",
-          "codebase": "master",
+          "codebase": "main",
           "tag": "4.0.0.Alpha2",
           "version": "4.0.0.Alpha2",
           "gav": "org.wildfly.core",


### PR DESCRIPTION
Update wildfly/wildfly-core community branch from master to main, otherwise pull-processor will falsely complain with `Upstream PR branch mismatched`